### PR TITLE
Fix API paths for user endpoints

### DIFF
--- a/data-services/network/src/commonMain/kotlin/com/grippo/network/Api.kt
+++ b/data-services/network/src/commonMain/kotlin/com/grippo/network/Api.kt
@@ -67,14 +67,14 @@ public class Api(private val client: NetworkClient) {
     public suspend fun deleteExcludedEquipment(id: String): Result<Unit> {
         return request(
             method = HttpMethod.Delete,
-            path = "users/excluded-equipments/$id"
+            path = "/users/excluded-equipments/$id"
         )
     }
 
     public suspend fun setExcludedEquipment(id: String): Result<Unit> {
         return request(
             method = HttpMethod.Post,
-            path = "users/excluded-equipments/$id"
+            path = "/users/excluded-equipments/$id"
         )
     }
 
@@ -88,14 +88,14 @@ public class Api(private val client: NetworkClient) {
     public suspend fun deleteExcludedMuscle(id: String): Result<Unit> {
         return request(
             method = HttpMethod.Delete,
-            path = "users/excluded-muscles/$id"
+            path = "/users/excluded-muscles/$id"
         )
     }
 
     public suspend fun setExcludedMuscle(id: String): Result<Unit> {
         return request(
             method = HttpMethod.Post,
-            path = "users/excluded-muscles/$id"
+            path = "/users/excluded-muscles/$id"
         )
     }
 

--- a/data-services/network/src/commonMain/kotlin/com/grippo/network/client/TokenProvider.kt
+++ b/data-services/network/src/commonMain/kotlin/com/grippo/network/client/TokenProvider.kt
@@ -181,7 +181,7 @@ internal class TokenProvider(
         client: HttpClient,
         refreshToken: String
     ): TokenResponse {
-        AppLogger.network("🌐 [TokenProvider] Sending refresh request to /auth/register")
+        AppLogger.network("🌐 [TokenProvider] Sending refresh request to /auth/refresh")
         return client.submitForm {
             url {
                 method = HttpMethod.Post


### PR DESCRIPTION
## Summary
- fix missing leading slashes in API endpoints for excluded equipment/muscle
- correct log message for token refresh request

## Testing
- `gradle test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f57b05ebc83339da90aa64121dab9